### PR TITLE
fix(deepresearch): fix ResearchTeamNode error and missing edge from research_team to planner, preventing possible infinite loop

### DIFF
--- a/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -260,7 +260,7 @@ public class DeepResearchConfiguration {
 					Map.of("planner", "planner", "research_team", "research_team", END, END))
 			.addConditionalEdges("research_team", edge_async(new ResearchTeamDispatcher()),
 					Map.of("professional_kb_decision", "professional_kb_decision", "parallel_executor",
-							"parallel_executor", END, END))
+							"parallel_executor", "planner", "planner", END, END))
 			.addConditionalEdges("professional_kb_decision", edge_async(new ProfessionalKbDispatcher()),
 					Map.of("professional_kb_rag", "professional_kb_rag", "reporter", "reporter", END, END))
 			.addEdge("professional_kb_rag", "reporter")

--- a/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearchTeamNode.java
+++ b/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearchTeamNode.java
@@ -54,7 +54,7 @@ public class ResearchTeamNode implements NodeAction {
 
 	public boolean areAllExecutionResultsPresent(Plan plan) {
 		if (CollectionUtils.isEmpty(plan.getSteps())) {
-			return false;
+			return true;
 		}
 
 		return plan.getSteps()


### PR DESCRIPTION
本PR修复以下问题：  
- **`ResearchTeamNode`** 目前的逻辑会造成进入`parallel_executor`后可能出现`curPlan`为`null`的现象，且可能因此造成`research_team_next_node`一直为`parallel_executor`而造成流程进入`research_team`后死循环。
- 根据 **`ResearchTeamDispatcher`** ，默认的情况下路径会进到`planner`，而 **`DeepResearchConfiguration`** 中从`research_team`出发的conditionalEdge缺少`planner`的mapping，因此也会造成流程无法运行到`END`。

---

This PR addresses and fixes the following issues:

* **`ResearchTeamNode`**'s current logic can lead to a scenario where **`curPlan`** becomes **`null`** after entering the **`parallel_executor`**. This can subsequently cause the **`research_team_next_node`** to perpetually remain the **`parallel_executor`**, resulting in a **deadlock** once the flow enters the **`research_team`**.
* According to the **`ResearchTeamDispatcher`**, the default path leads to the **`planner`**. However, the **`DeepResearchConfiguration`** is missing the **`planner`** mapping in the conditional edge starting from the **`research_team`**, which also prevents the flow from reaching **`END`**.
